### PR TITLE
編集機能実装

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,6 @@
 class PrototypesController < ApplicationController
-  before_action :move_to_session, except: [:index]
+  before_action :set_prototype, only: [:edit, :update, :show]
+  before_action :move_to_session, except: [:index, :show]
 
   def index
     @prototypes = Prototype.all
@@ -18,11 +19,28 @@ class PrototypesController < ApplicationController
     end
   end
 
+  def edit
+    return if @prototype.user == current_user
+    redirect_to root_path
+  end
+
+  def update
+    if @prototype.update(prototype_params)
+      redirect_to prototype_path
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def prototype_params
     params.require(:prototype).permit(:image, :prototype_title, :prototype_catch_copy,
                                       :prototype_concept).merge(user_id: current_user.id)
+  end
+
+  def set_prototype
+    @prototype = Prototype.find(params[:id])
   end
 
   def move_to_session

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,8 +1,8 @@
 <% @prototypes.each do |prototype| %>
   <div class="card">
-    <%= link_to image_tag(prototype.image, class: :card__img ), root_path%>
+    <%= link_to image_tag(prototype.image, class: :card__img ), prototype_path(prototype.id)%>
     <div class="card__body">
-      <%= link_to prototype.prototype_title, root_path, class: :card__title%>
+      <%= link_to prototype.prototype_title, prototype_path(prototype.id), class: :card__title%>
       <p class="card__summary">
         <%= prototype.prototype_catch_copy %>
       </p>

--- a/app/views/prototypes/edit.html.erb
+++ b/app/views/prototypes/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="inner">
     <div class="form__wrapper">
       <h2 class="page-heading">プロトタイプ編集</h2>
-      <%# 部分テンプレートでフォームを表示する %>
+        <%= render partial: "form", locals: { prototype: @prototype } %>
     </div>
   </div>
 </div>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -2,29 +2,29 @@
   <div class="inner">
     <div class="prototype__wrapper">
       <p class="prototype__hedding">
-        <%= "プロトタイプのタイトル"%>
+        <%= @prototype.prototype_title %>
       </p>
-      <%= link_to "by プロトタイプの投稿者", root_path, class: :prototype__user %>
-      <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
-        <div class="prototype__manage">
-          <%= link_to "編集する", root_path, class: :prototype__btn %>
-          <%= link_to "削除する", root_path, class: :prototype__btn %>
-        </div>
-      <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
+      <%= link_to "by #{@prototype.user.user_name}", root_path, class: :prototype__user %>
+        <% if user_signed_in? && current_user.id == @prototype.user.id  %>
+          <div class="prototype__manage">
+            <%= link_to "編集する", edit_prototype_path, class: :prototype__btn %>
+            <%= link_to "削除する", root_path, class: :prototype__btn %>
+          </div>
+        <% end %>
       <div class="prototype__image">
-        <%= image_tag "プロトタイプの画像" %>
+        <%= image_tag(@prototype.image) if @prototype.image.attached?  %>
       </div>
       <div class="prototype__body">
         <div class="prototype__detail">
           <p class="detail__title">キャッチコピー</p>
           <p class="detail__message">
-            <%= "プロトタイプのキャッチコピー" %>
+            <%= @prototype.prototype_catch_copy %>
           </p>
         </div>
         <div class="prototype__detail">
           <p class="detail__title">コンセプト</p>
           <p class="detail__message">
-            <%= "プロトタイプのコンセプト" %>
+            <%= @prototype.prototype_concept %>
           </p>
         </div>
       </div>


### PR DESCRIPTION
# What
編集機能実装
# Why
編集機能実装の為

ログイン状態の投稿者は、プロトタイプ情報編集ページに遷移できる動画
https://gyazo.com/75e6571b64715a75ba0c63cb13957485

必要な情報を適切に入力して「保存する」ボタンを押すと、プロトタイプの情報を編集できる動画
https://gyazo.com/d0ff6ecc6dd2b3acd30b7f9ca0a04ba0

入力に問題がある状態で「保存する」ボタンが押された場合、情報は保存されず、そのページに留まる動画
https://gyazo.com/f0d4c165ace8318f1bfaa23cf1ba5f8b

何も編集せずに「保存する」ボタンを押しても、画像無しのプロトタイプにならない動画
プロトタイプ情報について、すでに登録されている情報は、編集画面を開いた時点で表示される動画
この2つは以下の動画で確認できます。
https://gyazo.com/af2dc5a45331e8f281ab3f2744586c66

ログイン状態の場合でも、URLを直接入力して自身が投稿していないプロトタイプのプロトタイプ情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/a471ae25864560186363deea9c6adb08

ログアウト状態の場合は、URLを直接入力してプロトタイプ情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/d4b2ac383d6c892ff17db35cc5d4c35d
